### PR TITLE
Issue with MongoDB and MVC

### DIFF
--- a/Audit.Mvc/AuditAttribute.cs
+++ b/Audit.Mvc/AuditAttribute.cs
@@ -108,7 +108,7 @@ namespace Audit.Mvc
             IDictionary<string, string> dict = new Dictionary<string, string>();
             foreach (var k in col.AllKeys)
             {
-                dict.Add(k, col[k]);
+                dict.Add(k.Replace(".","_"), col[k]);
             }
             return dict;
         }

--- a/Audit.WebApi/AuditApiAttribute.cs
+++ b/Audit.WebApi/AuditApiAttribute.cs
@@ -107,7 +107,7 @@ namespace Audit.WebApi
             IDictionary<string, string> dict = new Dictionary<string, string>();
             foreach (var k in col)
             {
-                dict.Add(k.Key, string.Join(", ", k.Value));
+                dict.Add(k.Key.Replace(".","_"), string.Join(", ", k.Value));
             }
             return dict;
         }

--- a/Audit.WebApi/packages.config
+++ b/Audit.WebApi/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Audit.NET" version="2.5.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Occasional issue when using MVC and MongoDB - any keys that contain the "." symbol, it will fail with the exception of "Element name 'name' is not valid'.