### PR TITLE
Update column name for ID

### DIFF
--- a/src/Audit.NET.SqlServer/SqlScript.sql
+++ b/src/Audit.NET.SqlServer/SqlScript.sql
@@ -1,20 +1,20 @@
-﻿CREATE DATABASE [Audit]
+CREATE DATABASE [Audit]
 GO
 USE [Audit]
 GO
 CREATE TABLE [Event]
 (
-	EventId BIGINT IDENTITY(1,1) NOT NULL,
+	Id BIGINT IDENTITY(1,1) NOT NULL,
 	InsertedDate datetimeoffset NOT NULL DEFAULT(GETDATE()),
 	LastUpdatedDate datetimeoffset NOT NULL DEFAULT(GETDATE()),
 	[Data] NVARCHAR(MAX) NOT NULL,
-	CONSTRAINT PK_Event PRIMARY KEY (EventId)
+	CONSTRAINT PK_Event PRIMARY KEY (Id)
 )
 GO
 
 CREATE VIEW dbo.[v_Event] WITH SCHEMABINDING
 AS
-SELECT EventId, 
+SELECT Id, 
 	InsertedDate,
 	LastUpdatedDate,
 	CAST(JSON_VALUE(Data, '$.EventType') AS NVARCHAR(255)) AS [EventType],
@@ -34,7 +34,7 @@ SELECT EventId,
 FROM dbo.[Event]
 GO
 
-CREATE UNIQUE CLUSTERED INDEX PK_V_EVENT ON [v_Event] (EventId)
+CREATE UNIQUE CLUSTERED INDEX PK_V_EVENT ON [v_Event] (Id)
 CREATE INDEX IX_V_EVENT_EventType_ReferenceId ON [v_Event] (EventType, ReferenceId)
 CREATE INDEX IX_V_EVENT_CreatedDate ON [v_Event] (CreatedDate)
 CREATE INDEX IX_V_EVENT_CommitDate ON [v_Event] (CommitDate)


### PR DESCRIPTION
I'm not sure if this script is used behind the scenes, but I ran it manually and everything in it seemed fine except the primary key column (`EventId`, however the context appears to require `Id`).