### PR TITLE
Remove obsolete ef core package

### DIFF
--- a/src/Audit.EntityFramework.Core/Audit.EntityFramework.Core.csproj
+++ b/src/Audit.EntityFramework.Core/Audit.EntityFramework.Core.csproj
@@ -41,7 +41,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
   </ItemGroup>
 
@@ -55,7 +54,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Audit.EntityFramework/Audit.EntityFramework.csproj
+++ b/src/Audit.EntityFramework/Audit.EntityFramework.csproj
@@ -32,7 +32,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
According to comment https://github.com/aspnet/EntityFrameworkCore/issues/8923#issuecomment-310431600 Microsoft.EntityFrameworkCore.SqlServer.Design has been removed in EntityFrameworkCore 2.0 so it should no longer be referenced as a package