### PR TITLE
Fix the insert command for the Postgres provider

### DIFF
--- a/src/Audit.NET.PostgreSql/Providers/PostgreSqlDataProvider.cs
+++ b/src/Audit.NET.PostgreSql/Providers/PostgreSqlDataProvider.cs
@@ -214,7 +214,7 @@ namespace Audit.PostgreSql.Providers
             var cmd = cnn.CreateCommand();
             var schema = string.IsNullOrWhiteSpace(_schema) ? "" : (_schema + ".");
             var data = string.IsNullOrWhiteSpace(_dataType) ? "@data" : $"CAST (@data AS {_dataType})";
-            cmd.CommandText = $@"insert into {schema}""{_tableName}"" (""{_dataColumnName}"") values ({data}) RETURNING id";
+            cmd.CommandText = $@"insert into {schema}""{_tableName}"" (""{_dataColumnName}"") values ({data}) RETURNING (""{_idColumnName}"")";
             var parameter = cmd.CreateParameter();
             parameter.ParameterName = "data";
             parameter.Value = auditEvent.ToJson();


### PR DESCRIPTION
The insert command is not using the configured name for the event table's Id column, the default name 'id' is burned right into the code causing the operation to fail if you used any other name for the column.