### PR TITLE
AzureDbDataProvider - cache client

### DIFF
--- a/src/Audit.NET.AzureDocumentDB/Audit.NET.AzureDocumentDB.csproj
+++ b/src/Audit.NET.AzureDocumentDB/Audit.NET.AzureDocumentDB.csproj
@@ -8,7 +8,7 @@
     <Authors>Federico Colombo</Authors>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
-    <NoWarn>$(NoWarn);1591;3001</NoWarn>
+    <NoWarn>$(NoWarn);1573;1591;3001;3003</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Audit.NET.AzureDocumentDB</AssemblyName>
     <AssemblyOriginatorKeyFile>../StrongName/Audit.NET.snk</AssemblyOriginatorKeyFile>

--- a/src/Audit.NET.AzureDocumentDB/Audit.NET.AzureDocumentDB.csproj
+++ b/src/Audit.NET.AzureDocumentDB/Audit.NET.AzureDocumentDB.csproj
@@ -8,7 +8,7 @@
     <Authors>Federico Colombo</Authors>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <NoWarn>$(NoWarn);1591;3001</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Audit.NET.AzureDocumentDB</AssemblyName>
     <AssemblyOriginatorKeyFile>../StrongName/Audit.NET.snk</AssemblyOriginatorKeyFile>
@@ -28,13 +28,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.19.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.22.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.7.1" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Audit.NET.AzureDocumentDB/ConfigurationApi/DocumentDbConfiguratorExtensions.cs
+++ b/src/Audit.NET.AzureDocumentDB/ConfigurationApi/DocumentDbConfiguratorExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Audit.AzureDocumentDB.ConfigurationApi;
 using Audit.AzureDocumentDB.Providers;
 using Audit.Core.ConfigurationApi;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using System;
 
 namespace Audit.Core
@@ -13,15 +15,19 @@ namespace Audit.Core
         /// <param name="connectionString">The mongo DB connection string.</param>
         /// <param name="database">The mongo DB database name.</param>
         /// <param name="collection">The mongo DB collection name.</param>
-        public static ICreationPolicyConfigurator UseAzureDocumentDB(this IConfigurator configurator, string connectionString,
-            string authKey = null, string database = "Audit", string collection = "Event")
+        public static ICreationPolicyConfigurator UseAzureDocumentDB(
+            this IConfigurator configurator, string connectionString,
+            string authKey = null, string database = "Audit", string collection = "Event",
+            ConnectionPolicy connectionPolicy = null, IDocumentClient documentClient = null)
         {
             Configuration.DataProvider = new AzureDbDataProvider()
             {
                 ConnectionString = connectionString,
                 AuthKey = authKey,
                 Collection = collection,
-                Database = database
+                Database = database,
+                ConnectionPolicy = connectionPolicy,
+                DocumentClient = documentClient
             };
             return new CreationPolicyConfigurator();
         }
@@ -29,11 +35,20 @@ namespace Audit.Core
         /// Store the events in an Azure Document DB database.
         /// </summary>
         /// <param name="config">The Document DB provider configuration.</param>
-        public static ICreationPolicyConfigurator UseAzureDocumentDB(this IConfigurator configurator, Action<IDocumentDbProviderConfigurator> config)
+        public static ICreationPolicyConfigurator UseAzureDocumentDB(
+            this IConfigurator configurator, Action<IDocumentDbProviderConfigurator> config)
         {
             var documentDbConfig = new DocumentDbProviderConfigurator();
             config.Invoke(documentDbConfig);
-            return UseAzureDocumentDB(configurator, documentDbConfig._connectionString, documentDbConfig._authKey, documentDbConfig._database, documentDbConfig._collection);
+
+            return UseAzureDocumentDB(
+                configurator,
+                documentDbConfig._connectionString,
+                documentDbConfig._authKey,
+                documentDbConfig._database,
+                documentDbConfig._collection,
+                documentDbConfig._connectionPolicy,
+                documentDbConfig._documentClient);
         }
     }
 }

--- a/src/Audit.NET.AzureDocumentDB/ConfigurationApi/DocumentDbProviderConfigurator.cs
+++ b/src/Audit.NET.AzureDocumentDB/ConfigurationApi/DocumentDbProviderConfigurator.cs
@@ -1,11 +1,17 @@
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+
 namespace Audit.AzureDocumentDB.ConfigurationApi
 {
     public class DocumentDbProviderConfigurator : IDocumentDbProviderConfigurator
     {
-        internal string _connectionString = "mongodb://localhost:27017";
+        internal string _connectionString = string.Empty;
         internal string _authKey = null;
         internal string _database = "Audit";
-        internal string _collection = "Event";
+        internal string _collection = "Events";
+        internal ConnectionPolicy _connectionPolicy = null;
+        internal IDocumentClient _documentClient = null;
+
         public IDocumentDbProviderConfigurator ConnectionString(string connectionString)
         {
             _connectionString = connectionString;
@@ -27,6 +33,17 @@ namespace Audit.AzureDocumentDB.ConfigurationApi
         public IDocumentDbProviderConfigurator AuthKey(string authKey)
         {
             _authKey = authKey;
+            return this;
+        }
+
+        public IDocumentDbProviderConfigurator ConnectionPolicy(ConnectionPolicy connectionPolicy)
+        {
+            _connectionPolicy = connectionPolicy;
+            return this;
+        }
+        public IDocumentDbProviderConfigurator DocumentClient(IDocumentClient documentClient)
+        {
+            _documentClient = documentClient;
             return this;
         }
     }

--- a/src/Audit.NET.AzureDocumentDB/ConfigurationApi/IDocumentDbProviderConfigurator.cs
+++ b/src/Audit.NET.AzureDocumentDB/ConfigurationApi/IDocumentDbProviderConfigurator.cs
@@ -1,3 +1,6 @@
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+
 namespace Audit.AzureDocumentDB.ConfigurationApi
 {
     public interface IDocumentDbProviderConfigurator
@@ -22,5 +25,17 @@ namespace Audit.AzureDocumentDB.ConfigurationApi
         /// </summary>
         /// <param name="authKey">The auth key.</param>
         IDocumentDbProviderConfigurator AuthKey(string authKey);
+
+        /// <summary>
+        /// Specifies the Azure DocumentDB Client Connection Policy
+        /// </summary>
+        /// <param name="connectionPolicy">The connection policy.</param>
+        IDocumentDbProviderConfigurator ConnectionPolicy(ConnectionPolicy connectionPolicy);
+
+        /// <summary>
+        /// Specifies the Azure DocumentDB Client.
+        /// </summary>
+        /// <param name="documentClient">The configured document client object.</param>
+        IDocumentDbProviderConfigurator DocumentClient(IDocumentClient documentClient);
     }
 }

--- a/src/Audit.NET.AzureDocumentDB/README.md
+++ b/src/Audit.NET.AzureDocumentDB/README.md
@@ -28,6 +28,14 @@ Audit.Core.Configuration.DataProvider = new Audit.AzureDocumentDB.Providers.Azur
     ConnectionString = "https://mycompany.documents.azure.com:443/",
     AuthKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==",
     Database = "Audit",
+    Collection = "Event",
+	ConnectionPolicy = new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp }
+};
+
+Audit.Core.Configuration.DataProvider = new Audit.AzureDocumentDB.Providers.AzureDbDataProvider()
+{
+    DocumentClient = myClient,
+    Database = "Audit",
     Collection = "Event"
 };
 ```
@@ -39,14 +47,31 @@ Audit.Core.Configuration.Setup()
         .ConnectionString("https://mycompany.documents.azure.com:443/")
         .AuthKey("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
         .Database("Audit")
-        .Collection("Event"));
+        .Collection("Event")
+		.ConnectionPolicy(new ConnectionPolicy
+		{
+			ConnectionMode = ConnectionMode.Direct,
+			ConnectionProtocol = Protocol.Tcp
+		}));
+
+
+Audit.Core.Configuration.Setup()
+	.UseAzureDocumentDB(config => config
+		.DocumentClient(myClient)
+		.Database("Audit")
+        .Collection("Events");
 ```
 
 ### Provider options
 
-Mandatory:
+Mandatory config with a ConnectionString and an AuthKey:
 - **ConnectionString**: The Azure Document DB Connection String.
 - **AuthKey**: The Auth Key to use.
+- **Database**: The audit database name.
+- **Collection**: The events collection name.
+
+Or with a previously configured instance of DocumentClient:
+- **DocumentClient**: An already configured document client.
 - **Database**: The audit database name.
 - **Collection**: The events collection name.
 


### PR DESCRIPTION
AzureDbDataProvider - GetClient() method first initializes the client and uses the cached one for further calls. This way the time spent to create the connection is only used once.

In a normal day-to-day scenario, this improves Audit InsertEvent performance dramatically. From my tests using the Azure CosmosDb Emulator, it's as fast as using the FileLogProvider.