### PR TITLE
Fixed README.md (spaces vs tabs) and refactored InitializeClient a bit.

### DIFF
--- a/src/Audit.NET.AzureDocumentDB/Providers/AzureDbDataProvider.cs
+++ b/src/Audit.NET.AzureDocumentDB/Providers/AzureDbDataProvider.cs
@@ -170,10 +170,8 @@ namespace Audit.AzureDocumentDB.Providers
                     ConnectionProtocol = Protocol.Tcp
                 };
 
-            var client = new DocumentClient(new Uri(ConnectionStringBuilder?.Invoke(auditEvent)), AuthKeyBuilder?.Invoke(auditEvent), policy);
-            Task.Run(() => { client.OpenAsync(); });
-
-            DocumentClient = client;
+            DocumentClient = new DocumentClient(new Uri(ConnectionStringBuilder?.Invoke(auditEvent)), AuthKeyBuilder?.Invoke(auditEvent), policy);
+            Task.Run(() => { ((DocumentClient)DocumentClient).OpenAsync(); });
 
             return DocumentClient;
         }

--- a/src/Audit.NET.AzureDocumentDB/README.md
+++ b/src/Audit.NET.AzureDocumentDB/README.md
@@ -29,7 +29,7 @@ Audit.Core.Configuration.DataProvider = new Audit.AzureDocumentDB.Providers.Azur
     AuthKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==",
     Database = "Audit",
     CollectionBuilder = auditEvent => auditEvent.EventType,
-	ConnectionPolicy = new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp }
+    ConnectionPolicy = new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp }
 };
 
 Audit.Core.Configuration.DataProvider = new Audit.AzureDocumentDB.Providers.AzureDbDataProvider()
@@ -48,18 +48,18 @@ Audit.Core.Configuration.Setup()
         .AuthKey("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==")
         .Database("Audit")
         .Collection(auditEvent => auditEvent.EventType)
-		.ConnectionPolicy(new ConnectionPolicy
-		{
-			ConnectionMode = ConnectionMode.Direct,
-			ConnectionProtocol = Protocol.Tcp
-		}));
-
+        .ConnectionPolicy(new ConnectionPolicy
+        {
+            ConnectionMode = ConnectionMode.Direct,
+            ConnectionProtocol = Protocol.Tcp
+        }));
 
 Audit.Core.Configuration.Setup()
-	.UseAzureDocumentDB(config => config
-		.DocumentClient(myClient)
-		.Database("Audit")
-        .Collection("Events");
+    .UseAzureDocumentDB(config => config
+        .DocumentClient(myClient)
+        .Database("Audit")
+        .CollectionBuilder = auditEvent => auditEvent.EventType.StartsWith("GET") ? "Web" : "Custom"
+);
 ```
 
 ### Provider options


### PR DESCRIPTION
In the previous version of InitializeClient, I left in an extra initialization that didn't need to happen. It was there for debugging purposes. Now it's refactored out.

I also fixed the README.md to use the preferred Spaces instead of the VS default Tabs.