### PR TITLE
Update Microsoft.EntityFrameworkCore to 2.2.4

### DIFF
--- a/src/Audit.EntityFramework.Core/Audit.EntityFramework.Core.csproj
+++ b/src/Audit.EntityFramework.Core/Audit.EntityFramework.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Generate Audit Logs from EntityFramework context changes</Description>
@@ -48,8 +48,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 
@@ -59,8 +59,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Transactions" />

--- a/src/Audit.EntityFramework/Audit.EntityFramework.csproj
+++ b/src/Audit.EntityFramework/Audit.EntityFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Generate Audit Logs from EntityFramework context changes</Description>
@@ -39,8 +39,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 

--- a/test/Audit.EntityFramework.Core.UnitTest/Audit.EntityFramework.Core.UnitTest.csproj
+++ b/test/Audit.EntityFramework.Core.UnitTest/Audit.EntityFramework.Core.UnitTest.csproj
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.entityframeworkcore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.1" />
+    <PackageReference Include="microsoft.entityframeworkcore" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/test/Audit.EntityFramework.Core.UnitTest/EfCore22InMemoryTests.cs
+++ b/test/Audit.EntityFramework.Core.UnitTest/EfCore22InMemoryTests.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Audit.EntityFramework.Core.UnitTest
 {
     [TestFixture(Category = "EF")]
-    public class EfCore21InMemoryTests
+    public class EfCore22InMemoryTests
     {
         [SetUp]
         public void Setup()

--- a/test/Audit.EntityFramework.Core.UnitTest/EfCore22Tests.cs
+++ b/test/Audit.EntityFramework.Core.UnitTest/EfCore22Tests.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 namespace Audit.EntityFramework.Core.UnitTest
 {
     [TestFixture(Category = "EF")]
-    public class EfCore21Tests
+    public class EfCore22Tests
     {
         [OneTimeSetUp]
         public void Init()


### PR DESCRIPTION
Fixes issue with concurrency in concurrent integration tests and "Operations that change non-concurrent collections must have exclusive access" https://github.com/aspnet/EntityFrameworkCore/issues/12713