### PR TITLE
Add support in order to use the awaitable using blocks from C# 8.0

### DIFF
--- a/src/Audit.HttpClient/Audit.HttpClient.csproj
+++ b/src/Audit.HttpClient/Audit.HttpClient.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Audit.HttpClient</AssemblyTitle>
     <VersionPrefix>15.0.5</VersionPrefix>
     <Authors>Federico Colombo</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Audit.NET/Audit.NET.csproj
+++ b/src/Audit.NET/Audit.NET.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An extensible framework to audit executing operations in .NET and .NET Core.</Description>
     <Copyright>Copyright 2016</Copyright>
     <AssemblyTitle>Audit.NET</AssemblyTitle>
     <VersionPrefix>15.0.5</VersionPrefix>
     <Authors>Federico Colombo</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Audit.NET/AuditScope.cs
+++ b/src/Audit.NET/AuditScope.cs
@@ -13,6 +13,9 @@ namespace Audit.Core
     /// Makes a code block auditable.
     /// </summary>
     public partial class AuditScope : IDisposable
+#if NETSTANDARD2_1
+        , IAsyncDisposable
+#endif
     {
         private readonly AuditScopeOptions _options;
 #region Constructors
@@ -129,9 +132,9 @@ namespace Audit.Core
             }
             return this;
         }
-        #endregion
+#endregion
 
-        #region Public Properties
+#region Public Properties
         /// <summary>
         /// The current save mode. Useful on custom actions to determine the saving trigger.
         /// </summary>
@@ -186,7 +189,7 @@ namespace Audit.Core
                 return _creationPolicy;
             }
         }
-        #endregion
+#endregion
 
 #region Private fields
         private SaveMode _saveMode;
@@ -270,7 +273,11 @@ namespace Audit.Core
         /// Async version of the dispose method
         /// </summary>
         /// <returns></returns>
+#if NETSTANDARD2_1
+        public async ValueTask DisposeAsync()
+#else
         public async Task DisposeAsync()
+#endif
         {
             if (_disposed)
             {
@@ -461,6 +468,6 @@ namespace Audit.Core
             // Execute custom after saving actions
             Configuration.InvokeScopeCustomActions(ActionType.OnEventSaved, this);
         }
-        #endregion
+#endregion
     }
 }

--- a/test/Audit.UnitTest/Audit.UnitTest.csproj
+++ b/test/Audit.UnitTest/Audit.UnitTest.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.0;net461</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <DefineConstants>$(DefineConstants);STRONG_NAME</DefineConstants>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <AssemblyName>Audit.UnitTest</AssemblyName>

--- a/test/Audit.UnitTest/UnitTest.Async.cs
+++ b/test/Audit.UnitTest/UnitTest.Async.cs
@@ -434,6 +434,20 @@ namespace Audit.UnitTest
             provider.Verify(p => p.InsertEvent(It.IsAny<AuditEvent>()), Times.Exactly(1));
         }
 
+#if NETCOREAPP3_0
+        [Test]
+        public async Task Test_Dispose_Async()
+        {
+            var provider = new Mock<AuditDataProvider>();
+
+            await using (var scope = await AuditScope.CreateAsync(null, null, EventCreationPolicy.InsertOnEnd, dataProvider: provider.Object))
+            {               
+            }
+
+            provider.Verify(p => p.InsertEventAsync(It.IsAny<AuditEvent>()), Times.Exactly(1));
+        }
+#endif
+
         [Test]
         public async Task TestDiscard_Async()
         {

--- a/test/Audit.UnitTest/UnitTest.cs
+++ b/test/Audit.UnitTest/UnitTest.cs
@@ -729,6 +729,18 @@ namespace Audit.UnitTest
         }
 
         [Test]
+        public void Test_Dispose()
+        {
+            var provider = new Mock<AuditDataProvider>();
+
+            using (var scope = AuditScope.Create(null, null, EventCreationPolicy.InsertOnEnd, provider.Object))
+            {
+            }
+
+            provider.Verify(p => p.InsertEvent(It.IsAny<AuditEvent>()), Times.Exactly(1));
+        }
+
+        [Test]
         public void TestDiscard()
         {
             var provider = new Mock<AuditDataProvider>();


### PR DESCRIPTION
AuditScope implements `IAsyncDisposable` added in .Net Core 3.0 so it can be used within the ```await using``` contexts

So, for example, you can enable the following syntax from C# 8.0

```
Order order = Db.GetOrder(orderId);
await using (AuditScope.Create("Order:Update", () => order))
{
    order.Status = -1;
    order.OrderItems = null;
    order = Db.OrderUpdate(order);
}
```
The IDisposable interface is still supported
