### PR TITLE
Audit.WebApi - Use GetCurrentAuditScope when an HttpContext is missing

### DIFF
--- a/src/Audit.WebApi/AuditApiAdapter.Core.cs
+++ b/src/Audit.WebApi/AuditApiAdapter.Core.cs
@@ -252,6 +252,11 @@ namespace Audit.WebApi
 
         internal static AuditScope GetCurrentScope(HttpContext httpContext)
         {
+            if (httpContext == null)
+            {
+                return AuditScopeFactory.CreateNoOp();
+            }
+
             return httpContext.Items[AuditApiHelper.AuditApiScopeKey] as AuditScope;
         }
 

--- a/src/Audit.WebApi/AuditApiAdapter.cs
+++ b/src/Audit.WebApi/AuditApiAdapter.cs
@@ -213,6 +213,11 @@ namespace Audit.WebApi
 
         internal static AuditScope GetCurrentScope(HttpRequestMessage request, IContextWrapper contextWrapper)
         {
+            if (request == null)
+            {
+                return AuditScopeFactory.CreateNoOp();
+            }
+
             var ctx = contextWrapper ?? new ContextWrapper(request);
             return ctx.Get<AuditScope>(AuditApiHelper.AuditApiScopeKey);
         }

--- a/src/Audit.WebApi/AuditScopeFactory.cs
+++ b/src/Audit.WebApi/AuditScopeFactory.cs
@@ -1,0 +1,18 @@
+﻿using Audit.Core;
+using Audit.Core.Providers;
+using System.Runtime.CompilerServices;
+
+namespace Audit.WebApi
+{
+    internal class AuditScopeFactory
+    {
+        /// <summary>
+        /// Creates a no op audit scope
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static AuditScope CreateNoOp() => AuditScope.Create(new AuditScopeOptions
+        {
+            DataProvider = new DynamicDataProvider()
+        });
+    }
+}

--- a/src/Audit.WebApi/AuditScopeFactory.cs
+++ b/src/Audit.WebApi/AuditScopeFactory.cs
@@ -12,7 +12,7 @@ namespace Audit.WebApi
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static AuditScope CreateNoOp() => AuditScope.Create(new AuditScopeOptions
         {
-            DataProvider = new DynamicDataProvider()
+            DataProvider = new NullDataProvider()
         });
     }
 }

--- a/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
+++ b/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
@@ -47,7 +47,7 @@
     <ProjectReference Include="..\..\src\Audit.WebApi.Core\Audit.WebApi.Core.csproj" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
+++ b/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
@@ -40,13 +40,15 @@
     <ProjectReference Include="..\..\src\Audit.WebApi.Core\Audit.WebApi.Core.csproj" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <ProjectReference Include="..\..\src\Audit.WebApi.Core\Audit.WebApi.Core.csproj" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
-  </ItemGroup>  
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <ProjectReference Include="..\..\src\Audit.WebApi.Core\Audit.WebApi.Core.csproj" />

--- a/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.Core.cs
+++ b/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.Core.cs
@@ -1,0 +1,31 @@
+﻿#if NETCOREAPP1_0 || NETCOREAPP2_0 || NET451
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using System;
+
+namespace Audit.WebApi.UnitTest
+{
+    public class TestController : ControllerBase
+    {
+        public void TestAction()
+        {
+            var scope = this.GetCurrentAuditScope();
+            scope.SetCustomField("Field", 1);
+            scope.Save();
+        }
+    }
+
+    public class GetCurrentAuditScopeTest
+    {
+        [Test]
+        public void Test_CallingAnAction_ShouldNotThrow()
+        {
+            var sut = new TestController();
+
+            Action act = () => sut.TestAction();
+
+            Assert.DoesNotThrow(new TestDelegate(act));
+        }
+    }
+}
+#endif

--- a/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.Core.cs
+++ b/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.Core.cs
@@ -1,7 +1,9 @@
 ﻿#if NETCOREAPP1_0 || NETCOREAPP2_0 || NET451
+using Audit.Core;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 
 namespace Audit.WebApi.UnitTest
 {
@@ -20,11 +22,14 @@ namespace Audit.WebApi.UnitTest
         [Test]
         public void Test_CallingAnAction_ShouldNotThrow()
         {
-            var sut = new TestController();
+            var evs = new List<AuditEvent>();
+            Configuration.Setup().UseDynamicProvider(_ => _.OnInsertAndReplace(ev => evs.Add(ev)));
 
+            var sut = new TestController();
             Action act = () => sut.TestAction();
 
             Assert.DoesNotThrow(new TestDelegate(act));
+            Assert.AreEqual(0, evs.Count);
         }
     }
 }

--- a/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.cs
+++ b/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.cs
@@ -1,0 +1,31 @@
+﻿#if NET45
+using NUnit.Framework;
+using System;
+using System.Web.Http;
+
+namespace Audit.WebApi.UnitTest
+{
+    public class TestController : ApiController
+    {
+        public void TestAction()
+        {
+            var scope = this.GetCurrentAuditScope();
+            scope.SetCustomField("Field", 1);
+            scope.Save();
+        }
+    }
+
+    public class GetCurrentAuditScopeTest
+    {
+        [Test]
+        public void Test_CallingAnAction_ShouldNotThrow()
+        {
+            var sut = new TestController();
+
+            Action act = () => sut.TestAction();
+
+            Assert.DoesNotThrow(new TestDelegate(act));
+        }
+    }
+}
+#endif

--- a/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.cs
+++ b/test/Audit.WebApi.UnitTest/GetCurrentAuditScopeTest.cs
@@ -1,6 +1,8 @@
 ﻿#if NET45
+using Audit.Core;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Web.Http;
 
 namespace Audit.WebApi.UnitTest
@@ -20,8 +22,10 @@ namespace Audit.WebApi.UnitTest
         [Test]
         public void Test_CallingAnAction_ShouldNotThrow()
         {
-            var sut = new TestController();
+            var evs = new List<AuditEvent>();
+            Configuration.Setup().UseDynamicProvider(_ => _.OnInsertAndReplace(ev => evs.Add(ev)));
 
+            var sut = new TestController();
             Action act = () => sut.TestAction();
 
             Assert.DoesNotThrow(new TestDelegate(act));


### PR DESCRIPTION
Same for the when the HttpRequest is not present, such as in unit tests

Existing GetCurrentAuditScope assumes an HttpContext exists but this is not always the case, for example when the Controller classes are unit tested. In this case, a null reference is thrown.

One idea is to return a NoOp AuditScope to avoid producing side effects, like saving the events on the file system.