### PR TITLE
Enable disposable async for netstandard2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ public async Task SaveOrderAsync(Order order)
 }
 ```
 
-> Note: On older .NET framework versions [the `Dispose` method was always synchronous](https://github.com/dotnet/roslyn/issues/114), so if your audit code is on async methods and you created the scope within a `using` statement, you should explicitly call the `DisposeAsync()` method. For .NET Core starting on version 3.0 and C# 8, you can simply use the `await using` statement, since the `AuditScope` implements the [`IAsyncDisposable` interface](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable).
+> Note: On older .NET framework versions [the `Dispose` method was always synchronous](https://github.com/dotnet/roslyn/issues/114), so if your audit code is on async methods and you created the scope within a `using` statement, you should explicitly call the `DisposeAsync()` method. For projects targeting .NET Standard starting on version 2.0 and C# 8, you can simply use the `await using` statement, since the `AuditScope` implements the [`IAsyncDisposable` interface](https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable).
 
 ## Output
 

--- a/src/Audit.NET/Audit.NET.csproj
+++ b/src/Audit.NET/Audit.NET.csproj
@@ -43,6 +43,9 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="images\icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>

--- a/src/Audit.NET/AuditScope.cs
+++ b/src/Audit.NET/AuditScope.cs
@@ -13,7 +13,7 @@ namespace Audit.Core
     /// Makes a code block auditable.
     /// </summary>
     public partial class AuditScope : IDisposable
-#if NETSTANDARD2_1
+#if NETSTANDARD2_0 || NETSTANDARD2_1
         , IAsyncDisposable
 #endif
     {
@@ -273,7 +273,7 @@ namespace Audit.Core
         /// Async version of the dispose method
         /// </summary>
         /// <returns></returns>
-#if NETSTANDARD2_1
+#if NETSTANDARD2_0 || NETSTANDARD2_1
         public async ValueTask DisposeAsync()
 #else
         public async Task DisposeAsync()

--- a/test/Audit.UnitTest/UnitTest.Async.cs
+++ b/test/Audit.UnitTest/UnitTest.Async.cs
@@ -434,7 +434,7 @@ namespace Audit.UnitTest
             provider.Verify(p => p.InsertEvent(It.IsAny<AuditEvent>()), Times.Exactly(1));
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP2_0 || NETCOREAPP3_0
         [Test]
         public async Task Test_Dispose_Async()
         {


### PR DESCRIPTION
Asynchronous disposing can be enabled for netstandard2.0 too
if the Microsoft.Bcl.AsyncInterfaces package is used.