### PR TITLE
Enhance CLR resolve in EF Core

### DIFF
--- a/src/Audit.EntityFramework/Providers/EntityFrameworkDataProvider.cs
+++ b/src/Audit.EntityFramework/Providers/EntityFrameworkDataProvider.cs
@@ -177,8 +177,8 @@ namespace Audit.EntityFramework.Providers
             }
             Type type;
 #if EF_CORE && (NETSTANDARD2_0 || NETSTANDARD2_1 || NET472)
-            IEntityType definingType = entry.Entry.Metadata.DefiningEntityType ?? localDbContext.Model.FindEntityType(entryType);
-                type = definingType?.ClrType;
+            IEntityType definingType = entry.Entry.Metadata.DefiningEntityType ?? localDbContext.Model.FindRuntimeEntityType(entryType);
+            type = definingType?.ClrType;
 #elif NETSTANDARD1_5 || NET461
             IEntityType definingType = localDbContext.Model.FindEntityType(entryType);
             type = definingType?.ClrType;


### PR DESCRIPTION
Hi

In our project we have some derived / proxy classes to represent our entities (types that inherit from an entity defined on the `DbContext` but that themselves are not). EF handles these classes fine, but despite the `AuditEvent` being created with all the entities it was not being persisted by Audit.NET.

I tracked the cause to the code in `EntityFrameworkDataProvider.InsertEvent` where the call to `GetEntityType()` would return `null` for these type of classes. I propose a small tweak to how the `Clr` type is resolved using [this method instead](https://github.com/dotnet/efcore/blob/main/src/EFCore/Extensions/ModelExtensions.cs#L44-L53). It should have the exact behavior as the `FindEntityType` being called now, but will also check the base class if needed.
