### PR TITLE
restore original body for upstream pipelines

### DIFF
--- a/src/Audit.WebApi/AuditMiddleware.cs
+++ b/src/Audit.WebApi/AuditMiddleware.cs
@@ -55,6 +55,7 @@ namespace Audit.WebApi
                     await InvokeNextAsync(context, true, includeResponseHeaders);
                     responseBody.Seek(0L, SeekOrigin.Begin);
                     await responseBody.CopyToAsync(originalBody);
+                    context.Response.Body = originalBody;
                 }
             }
             else


### PR DESCRIPTION
Greetings

if an upstream pipeline defers processing until after audit.net has run without tracking the reference to the original body into a variable (i.e. it just reads the Response.Body at the point it runs), it gets back a disposed stream.

have made a small adjustment to set the original body you copied to.

Thanks