### PR TITLE
Update Amazon.QLDB.Driver to 1.0.1 as it supports .NET Framework 4.6.1 now

### DIFF
--- a/src/Audit.NET.AmazonQLDB/Audit.NET.AmazonQLDB.csproj
+++ b/src/Audit.NET.AmazonQLDB/Audit.NET.AmazonQLDB.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Amazon.QLDB.Driver" Version="1.0.0" />
+    <PackageReference Include="Amazon.QLDB.Driver" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Audit.NET.DynamoDB/Audit.NET.DynamoDB.csproj
+++ b/src/Audit.NET.DynamoDB/Audit.NET.DynamoDB.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.13" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 

--- a/test/Audit.IntegrationTest/AmazonQLDBTests.cs
+++ b/test/Audit.IntegrationTest/AmazonQLDBTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0 || NETCOREAPP3_0
+﻿#if NET461 || NETCOREAPP2_0 || NETCOREAPP3_0
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/test/Audit.IntegrationTest/Audit.IntegrationTest.csproj
+++ b/test/Audit.IntegrationTest/Audit.IntegrationTest.csproj
@@ -48,7 +48,6 @@
   </ItemGroup>  
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'net452' and '$(TargetFramework)' != 'net461'">
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.13.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
   </ItemGroup>  
 

--- a/test/Audit.IntegrationTest/IntegrationTests.cs
+++ b/test/Audit.IntegrationTest/IntegrationTests.cs
@@ -575,7 +575,7 @@ namespace Audit.IntegrationTest
                 await TestUpdateAsync();
             }
 #endif
-#if NETCOREAPP2_0 || NETCOREAPP3_0
+#if NET461 || NETCOREAPP2_0 || NETCOREAPP3_0
             [Test]
             [Category("AmazonQLDB")]
             public void TestAmazonQLDB()


### PR DESCRIPTION
Update Amazon.QLDB.Driver to 1.0.1 as [it supports .NET Framework 4.6.1 now](https://github.com/awslabs/amazon-qldb-driver-dotnet/issues/31)
Update AWSSDK.DynamoDBv2 to 3.5.0 to share the same minor version (3.5), otherwise IntegrationTests project doesn't build (the alternative would be to have separate integration projects, I'm open to suggestions here if the upgrade on DynamoDb is not desired).
Remove AWSSDK.DynamoDBv2 reference from integration tests, as it is inherited via the provider projects

~~Side note:
I tried to run the integration tests for .NET Core 2.0 but I am not able to do so because of some build errors. The command I'm using is
`dotnet test --filter Test_AmazonQLDB_HappyPath -f netcoreapp20`
I don't getthe same error with `net461`~~
Ignore the side note please, I'm in wrong with the framework parameters, should be netcoreapp2.0.

