### PR TITLE
Fix null reference exception for mySQL data provider when using custom transactions

### DIFF
--- a/src/Audit.EntityFramework/DbContextHelper.cs
+++ b/src/Audit.EntityFramework/DbContextHelper.cs
@@ -425,7 +425,9 @@ namespace Audit.EntityFramework
             var propIntTran = transaction.GetType().GetTypeInfo().GetProperty("InternalTransaction", BindingFlags.NonPublic | BindingFlags.Instance);
             object intTran = propIntTran?.GetValue(transaction);
             var propTranId = intTran?.GetType().GetTypeInfo().GetProperty("TransactionId", BindingFlags.NonPublic | BindingFlags.Instance);
-            var tranId = (int)(long)propTranId?.GetValue(intTran);
+            var tranId = 0;
+            if (propTranId != null)
+                tranId = (int)(long)propTranId.GetValue(intTran);
             return string.Format("{0}_{1}", clientConnectionId, tranId);
         }
 

--- a/src/Audit.EntityFramework/DbContextHelper.cs
+++ b/src/Audit.EntityFramework/DbContextHelper.cs
@@ -425,10 +425,8 @@ namespace Audit.EntityFramework
             var propIntTran = transaction.GetType().GetTypeInfo().GetProperty("InternalTransaction", BindingFlags.NonPublic | BindingFlags.Instance);
             object intTran = propIntTran?.GetValue(transaction);
             var propTranId = intTran?.GetType().GetTypeInfo().GetProperty("TransactionId", BindingFlags.NonPublic | BindingFlags.Instance);
-            var tranId = 0;
-            if (propTranId != null)
-                tranId = (int)(long)propTranId.GetValue(intTran);
-            return string.Format("{0}_{1}", clientConnectionId, tranId);
+            var tranId = propTranId?.GetValue(intTran);
+            return string.Format("{0}_{1}", clientConnectionId, tranId ?? 0);
         }
 
         public string GetClientConnectionId(DbConnection connection)


### PR DESCRIPTION
When making use of the mySQL data provider I attempted to make a custom database transaction using DbContextTransaction (sample below) this resulted in a null transaction id from the GetTransactionId helper method which in turn resulted in a null reference exception when trying to perform the int and long type casts.

This PR aims to fix that by performing a null check prior to the casting.

Custom transaction sample:

```
using (DbContextTransaction dbContextTransaction = DBContext.Database.BeginTransaction())
{
   foreach (int userID in userIDs)
   {
      User user = DBContext.Users.FirstOrDefault(u => u.Id == userID);
      user.name = "Steven";

      await DBContext.SaveChanges();
    }
    dbContextTransaction.Commit();
}
```