### PR TITLE
Extend Format options to match FormatProperties dictionary

### DIFF
--- a/src/Audit.EntityFramework/ConfigurationApi/ContextEntitySetting.cs
+++ b/src/Audit.EntityFramework/ConfigurationApi/ContextEntitySetting.cs
@@ -17,7 +17,20 @@ namespace Audit.EntityFramework.ConfigurationApi
             return this;
         }
 
+        public IContextEntitySetting<TEntity> Format<TProp>(Expression<Func<TEntity, TProp>> property, Func<TProp, object> format)
+        {
+            var name = GetMemberName(property);
+            FormatProperties[name] = entity => format.Invoke((TProp)entity);
+            return this;
+        }
+
         public IContextEntitySetting<TEntity> Format<TProp>(string propertyName, Func<TProp, TProp> format)
+        {
+            FormatProperties[propertyName] = entity => format.Invoke((TProp)entity);
+            return this;
+        }
+
+        public IContextEntitySetting<TEntity> Format<TProp>(string propertyName, Func<TProp, object> format)
         {
             FormatProperties[propertyName] = entity => format.Invoke((TProp)entity);
             return this;

--- a/src/Audit.EntityFramework/ConfigurationApi/IContextEntitySetting.cs
+++ b/src/Audit.EntityFramework/ConfigurationApi/IContextEntitySetting.cs
@@ -42,9 +42,21 @@ namespace Audit.EntityFramework.ConfigurationApi
         /// <summary>
         /// Overrides a column value to a value given as a function of the current value.
         /// </summary>
+        /// <param name="property">The property selector. Must be a simple property expression i.e. x -> x.PropertyName</param>
+        /// <param name="format">A function of the current value that returns the value to override</param>
+        IContextEntitySetting<TEntity> Format<TProp>(Expression<Func<TEntity, TProp>> property, Func<TProp, object> format);
+        /// <summary>
+        /// Overrides a column value to a value given as a function of the current value.
+        /// </summary>
         /// <param name="propertyName">The entity's property name (case sensitive)</param>
         /// <param name="format">A function of the current value that returns the value to override</param>
         IContextEntitySetting<TEntity> Format<TProp>(string propertyName, Func<TProp, TProp> format);
+        /// <summary>
+        /// Overrides a column value to a value given as a function of the current value.
+        /// </summary>
+        /// <param name="propertyName">The entity's property name (case sensitive)</param>
+        /// <param name="format">A function of the current value that returns the value to override</param>
+        IContextEntitySetting<TEntity> Format<TProp>(string propertyName, Func<TProp, object> format);
     }
 }
  

--- a/test/Audit.IntegrationTest/EntityFrameworkTests.cs
+++ b/test/Audit.IntegrationTest/EntityFrameworkTests.cs
@@ -46,13 +46,16 @@ namespace Audit.IntegrationTest
                     .ForEntity<IntegrationTest.Blog>(_ => _.Ignore(blog => blog.BloggerName)));
             Audit.EntityFramework.Configuration.Setup()
                 .ForAnyContext(config => config
-                    .ForEntity<IntegrationTest.Blog>(_ => _.Format(b => b.Title, t => t + "X")));
+                    .ForEntity<IntegrationTest.Blog>(_ => _.Format(b => b.Title, t => t + "X")
+                                                           .Format(b => b.Id, t => t + "X")));
 
             var title = Guid.NewGuid().ToString().Substring(0, 25);
+            var id = 1;
             using (var ctx = new MyTransactionalContext())
             {
                 var blog = new Blog()
                 {
+                    Id = id,
                     Title = title,
                     BloggerName = "test"
                 };
@@ -73,6 +76,7 @@ namespace Audit.IntegrationTest
             Assert.AreEqual("Insert", entries[0].Action);
             Assert.IsFalse(entries[0].ColumnValues.ContainsKey("BloggerName"));
             Assert.AreEqual(title + "X", entries[0].ColumnValues["Title"]);
+            Assert.AreEqual(id + "X", entries[0].ColumnValues["Id"]);
             entries = list[1].EntityFrameworkEvent.Entries;
             Assert.AreEqual(1, entries.Count);
             Assert.AreEqual("Update", entries[0].Action);


### PR DESCRIPTION
Add support to return any type from format action

```
.ForEntity<IntegrationTest.Blog>(_ => _.Format(b => b.Title, t => t + "X")
                                                           .Format(b => b.Id, t => t + "X")));

```
