### PR TITLE
Fix parallelization of unit tests in WebApi

### DIFF
--- a/src/Audit.WebApi/AuditApiAdapter.Core.cs
+++ b/src/Audit.WebApi/AuditApiAdapter.Core.cs
@@ -19,6 +19,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Http.Extensions;
 using System.Runtime.CompilerServices;
 using Audit.Core.Providers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Audit.WebApi
 {
@@ -74,7 +75,14 @@ namespace Audit.WebApi
             {
                 Action = auditAction
             };
-            var auditScope = await AuditScope.CreateAsync(new AuditScopeOptions() { EventType = eventType, AuditEvent = auditEventAction, CallingMethod = actionDescriptor.MethodInfo });
+            var dataProvider = actionContext.HttpContext.RequestServices.GetService<AuditDataProvider>();
+            var auditScope = await AuditScope.CreateAsync(new AuditScopeOptions()
+            {
+                EventType = eventType, 
+                AuditEvent = auditEventAction, 
+                CallingMethod = actionDescriptor?.MethodInfo, 
+                DataProvider = dataProvider
+            });
             httpContext.Items[AuditApiHelper.AuditApiActionKey] = auditAction;
             httpContext.Items[AuditApiHelper.AuditApiScopeKey] = auditScope;
         }

--- a/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
+++ b/test/Audit.WebApi.UnitTest/Audit.WebApi.UnitTest.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.17" />
     <ProjectReference Include="..\..\src\Audit.WebApi.Core\Audit.WebApi.Core.csproj" />
   </ItemGroup>
 

--- a/test/Audit.WebApi.UnitTest/IsolationTests.cs
+++ b/test/Audit.WebApi.UnitTest/IsolationTests.cs
@@ -29,11 +29,12 @@ namespace Audit.WebApi.UnitTest
     
     public class TestHelper
     {
-        public static TestServer GetTestServer()
+        public static TestServer GetTestServer(AuditDataProvider dataProvider)
         {
             return new TestServer(WebHost.CreateDefaultBuilder()
                 .ConfigureServices(services =>
                 {
+                    services.AddSingleton(dataProvider);
                     services.AddControllers();
                 })
                 .Configure((ctx, app) =>
@@ -54,57 +55,53 @@ namespace Audit.WebApi.UnitTest
         [Test]
         public async Task Test1()
         {
-            Configuration.Setup().UseInMemoryProvider();
-            
-            using var app = TestHelper.GetTestServer();
+            var dataProvider = new InMemoryDataProvider();
+            using var app = TestHelper.GetTestServer(dataProvider);
             using var client = app.CreateClient();
 
             var response = await client.GetAsync("/test2/action");
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+            Assert.AreEqual(1, dataProvider.GetAllEvents().Count);
         }
         
         [Test]
         public async Task Test2()
         {
-            Configuration.Setup().UseInMemoryProvider();
-            
-            using var app = TestHelper.GetTestServer();
+            var dataProvider = new InMemoryDataProvider();
+            using var app = TestHelper.GetTestServer(dataProvider);
             using var client = app.CreateClient();
 
             var response = await client.GetAsync("/test2/action");
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+            Assert.AreEqual(1, dataProvider.GetAllEvents().Count);
         }
         
         [Test]
         public async Task Test3()
         {
-            Configuration.Setup().UseInMemoryProvider();
-            
-            using var app = TestHelper.GetTestServer();
+            var dataProvider = new InMemoryDataProvider();
+            using var app = TestHelper.GetTestServer(dataProvider);
             using var client = app.CreateClient();
 
             var response = await client.GetAsync("/test2/action");
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+            Assert.AreEqual(1, dataProvider.GetAllEvents().Count);
         }
         
         [Test]
         public async Task Test4()
         {
-            Configuration.Setup().UseInMemoryProvider();
-            
-            using var app = TestHelper.GetTestServer();
+            var dataProvider = new InMemoryDataProvider();
+            using var app = TestHelper.GetTestServer(dataProvider);
             using var client = app.CreateClient();
 
             var response = await client.GetAsync("/test2/action");
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+            Assert.AreEqual(1, dataProvider.GetAllEvents().Count);
         }
     }
 }

--- a/test/Audit.WebApi.UnitTest/IsolationTests.cs
+++ b/test/Audit.WebApi.UnitTest/IsolationTests.cs
@@ -1,0 +1,111 @@
+﻿#if NET5_0
+using System.Net;
+using System.Threading.Tasks;
+using Audit.Core;
+using Audit.Core.Providers;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+// this test shall run execution in parallel and check if isolated data providers are correctly implemented
+
+namespace Audit.WebApi.UnitTest
+{
+    [Route("[controller]/[action]")]
+    [ApiController]
+    public class Test2Controller : ControllerBase
+    {
+        [AuditApi]
+        [HttpGet]
+        public IActionResult Action()
+        {
+            return Ok();
+        }
+    }
+    
+    public class TestHelper
+    {
+        public static TestServer GetTestServer()
+        {
+            return new TestServer(WebHost.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.AddControllers();
+                })
+                .Configure((ctx, app) =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e =>
+                    {
+                        e.MapControllers();
+                    });
+                })
+            );
+        }
+    }
+    
+    [Parallelizable(ParallelScope.Children)]
+    public class IsolationTests
+    {
+        [Test]
+        public async Task Test1()
+        {
+            Configuration.Setup().UseInMemoryProvider();
+            
+            using var app = TestHelper.GetTestServer();
+            using var client = app.CreateClient();
+
+            var response = await client.GetAsync("/test2/action");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+        }
+        
+        [Test]
+        public async Task Test2()
+        {
+            Configuration.Setup().UseInMemoryProvider();
+            
+            using var app = TestHelper.GetTestServer();
+            using var client = app.CreateClient();
+
+            var response = await client.GetAsync("/test2/action");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+        }
+        
+        [Test]
+        public async Task Test3()
+        {
+            Configuration.Setup().UseInMemoryProvider();
+            
+            using var app = TestHelper.GetTestServer();
+            using var client = app.CreateClient();
+
+            var response = await client.GetAsync("/test2/action");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+        }
+        
+        [Test]
+        public async Task Test4()
+        {
+            Configuration.Setup().UseInMemoryProvider();
+            
+            using var app = TestHelper.GetTestServer();
+            using var client = app.CreateClient();
+
+            var response = await client.GetAsync("/test2/action");
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, ((InMemoryDataProvider)Configuration.DataProvider).GetAllEvents().Count);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes #557 

`AuditApiAdapter` (Core) will respect any `AuditDataProvider` in the service collection of the host as target data provider. This allows isolation on a per request base. This is usually not important as the audit logger is used as singleton anyway. However this makes parallel unit tests possible.

This is opt-in. If you do not add any `AuditDataProvider` to the services it uses the old logic: Use the global configuration.