### PR TITLE
Added an option to discard audit scope if HttpStatusCode does not match

### DIFF
--- a/src/Audit.WebApi/AuditApiAttribute.Core.cs
+++ b/src/Audit.WebApi/AuditApiAttribute.Core.cs
@@ -72,9 +72,10 @@ namespace Audit.WebApi
         public bool SerializeActionParameters { get; set; }
         /// <summary>
         /// Gets or sets an array of status codes that conditionally indicates when the Audit scope should be discarded.
-        /// The Audit action is triggered only when the request return a status code not in this array.
+        /// The Audit action is triggered only when the request return a status code in this array. 
+        /// If the array is left empty, it means that audit happens regardless of status code.
         /// </summary>
-        public HttpStatusCode[] DiscardFor { get; set; }
+        public HttpStatusCode[] DiscardIfNot { get; set; }
 
         public AuditApiAttribute()
         {
@@ -101,7 +102,7 @@ namespace Audit.WebApi
 
         private bool ShouldDiscardForResponseStatus(ActionExecutedContext context) => ShouldDiscardForResponseStatus(GetStatusCode(context));
 
-        private bool ShouldDiscardForResponseStatus(HttpStatusCode statusCode) => DiscardFor != null && DiscardFor.Contains(statusCode);
+        private bool ShouldDiscardForResponseStatus(HttpStatusCode statusCode) => DiscardIfNot != null && !DiscardIfNot.Contains(statusCode);
 
         private bool ShouldIncludeResponseBody(ActionExecutedContext context)
         {

--- a/test/Audit.Integration.AspNetCore/Controllers/ValuesController.cs
+++ b/test/Audit.Integration.AspNetCore/Controllers/ValuesController.cs
@@ -116,7 +116,7 @@ namespace Audit.Integration.AspNetCore.Controllers
         }
 
         [HttpPost("TestDiscardStatusCode")]
-        [AuditApi(DiscardFor = new[] { HttpStatusCode.BadRequest })]
+        [AuditApi(DiscardIfNot = new[] { HttpStatusCode.OK })]
         [return: AuditIgnore]
         public async Task<IActionResult> TestIgnoreResponseFilter()
         {

--- a/test/Audit.Integration.AspNetCore/Controllers/ValuesController.cs
+++ b/test/Audit.Integration.AspNetCore/Controllers/ValuesController.cs
@@ -115,6 +115,15 @@ namespace Audit.Integration.AspNetCore.Controllers
             return Ok("hi from filter");
         }
 
+        [HttpPost("TestDiscardStatusCode")]
+        [AuditApi(DiscardFor = new[] { HttpStatusCode.BadRequest })]
+        [return: AuditIgnore]
+        public async Task<IActionResult> TestIgnoreResponseFilter()
+        {
+            await Task.Delay(0);
+            return BadRequest("This is a bad request to test filter response");
+        }
+
         [AuditIgnore] // ignored here but will be picked up by the middleware
         [HttpPost("TestResponseHeaders")]
         public async Task<IActionResult> TestResponseHeaders(string id)

--- a/test/Audit.Integration.AspNetCore/WebApiTests.cs
+++ b/test/Audit.Integration.AspNetCore/WebApiTests.cs
@@ -647,6 +647,28 @@ namespace Audit.Integration.AspNetCore
         }
 
         [Test]
+        public async Task Test_WebApi_Audit_Action_DiscardIf()
+        {
+            var insertEvs = new List<AuditEvent>();
+            Audit.Core.Configuration.Setup()
+                .UseDynamicAsyncProvider(_ => _.OnInsert(async ev =>
+                {
+                    await Task.Delay(1);
+                    insertEvs.Add(ev);
+                    return Guid.NewGuid();
+                }))
+                .WithCreationPolicy(EventCreationPolicy.InsertOnEnd);
+
+            var url = $"api/values/TestDiscardStatusCode";
+
+            var req = new HttpRequestMessage(HttpMethod.Post, url);
+            var res = await _httpClient.SendAsync(req);
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, res.StatusCode);
+            Assert.AreEqual(0, insertEvs.Count);
+        }
+
+        [Test]
         public async Task Test_WebApi_FormCollectionLimit_Async()
         {
             var insertEvs = new List<AuditEvent>();

--- a/test/Audit.Integration.AspNetCore/WebApiTests.cs
+++ b/test/Audit.Integration.AspNetCore/WebApiTests.cs
@@ -647,7 +647,7 @@ namespace Audit.Integration.AspNetCore
         }
 
         [Test]
-        public async Task Test_WebApi_Audit_Action_DiscardIf()
+        public async Task Test_WebApi_Audit_Action_DiscardIfNot()
         {
             var insertEvs = new List<AuditEvent>();
             Audit.Core.Configuration.Setup()


### PR DESCRIPTION
Added a new property to the `AuditApiAttribute` which discards the Audit scope in case the resulting httpstatuscode is not included in the list of valid status codes.

This may very well be a bit too generic - perhaps a simpler versioner would be `DiscardIfNotSuccess` its less flexible, but it reduces the option to a bool, and the statuscode to something like `statusCode >= 200 && statusCode <= 299`
